### PR TITLE
Missing/incorrect dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click
 numpy>=1.11
 dm-sonnet>=1.20
 tensorflow>=1.8.0
+mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click
 numpy>=1.11
-sonnet>=1.20
+dm-sonnet>=1.20
 tensorflow>=1.8.0

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
     long_description=read('README.md'),
     license='MIT',
     install_requires=[
-        'click', 'numpy>=1.11', 'dm-sonnet>=1.20', 'tensorflow>=1.8.0',
+        'click', 'numpy>=1.11', 'dm-sonnet>=1.20', 'tensorflow>=1.8.0', 'mock'
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
 import os
+
 from setuptools import setup, find_packages
+
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
 
 setup(
     name='lola',
@@ -12,6 +15,6 @@ setup(
     long_description=read('README.md'),
     license='MIT',
     install_requires=[
-        'click', 'numpy>=1.11', 'sonnet>=1.20', 'tensorflow>=1.8.0',
+        'click', 'numpy>=1.11', 'dm-sonnet>=1.20', 'tensorflow>=1.8.0',
     ],
 )


### PR DESCRIPTION
The requirements point to the pypi sonnet package, however, this is not correct.
The dm-sonnet package should be used instead.